### PR TITLE
Add certificates dependency to curl.

### DIFF
--- a/meta/recipes-support/curl/curl_7.53.1.bb
+++ b/meta/recipes-support/curl/curl_7.53.1.bb
@@ -9,6 +9,8 @@ SRC_URI = "http://curl.haxx.se/download/curl-${PV}.tar.bz2 \
            file://0001-replace-krb5-config-with-pkg-config.patch \
 "
 
+DEPENDS = "ca-certificates"
+
 # curl likes to set -g0 in CFLAGS, so we stop it
 # from mucking around with debug options
 #


### PR DESCRIPTION
The built curl is used during the builds, and any download using an https link (e.g. from github) requires the certificates, so these must be installed before curl is available.
(Actually, absolute links get installed, so you also need to be using a build system with the relevant certs in place but this will be true).
This was breaking stb-kodi builds on openViX.